### PR TITLE
📝 Update version to 1.10.2 and fix HTML comment injection in Jinja2 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.10.2
+
+### Patch Changes
+
+- Fix HTML comment injection inside `<style>` and `<script>` blocks
+  - Removed `"include": "text.html.basic"` from the injection grammar. Re-including it inside an injection grammar caused HTML comment patterns to bleed into embedded CSS and JS scopes.
+  - Removed `"language": "html"` from the grammar contribution in `package.json`, converting it to a pure injection grammar. VS Code's built-in HTML grammar now handles HTML parsing; this extension only injects Jinja2 patterns on top.
+  - Changed `injectionSelector` from `"text.html"` to `"L:text.html"` so Jinja2 `{% %}` and `{{ }}` patterns are still applied inside `<style>` and `<script>` blocks.
+
 ## 1.10.1
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jinja2-html-enhancer",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jinja2-html-enhancer",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/cli": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jinja2-html-enhancer",
   "displayName": "Jinja2 Enhance",
   "description": "Syntax highlighting and variable checking for Jinja2 templates",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "publisher": "Xubylele",
   "icon": "resources/logo.png",
   "engines": {
@@ -78,7 +78,6 @@
     ],
     "grammars": [
       {
-        "language": "html",
         "scopeName": "text.html.jinja2",
         "path": "./syntaxes/jinja2.tmLanguage.json",
         "injectTo": [

--- a/syntaxes/jinja2.tmLanguage.json
+++ b/syntaxes/jinja2.tmLanguage.json
@@ -1,10 +1,7 @@
 {
   "scopeName": "text.html.jinja2",
-  "injectionSelector": "text.html",
+  "injectionSelector": "L:text.html",
   "patterns": [
-    {
-      "include": "text.html.basic"
-    },
     {
       "name": "meta.tag.jinja2",
       "begin": "{%",


### PR DESCRIPTION
This PR closes the issue #26 